### PR TITLE
docs: fixed typo in deployment.md

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -32,7 +32,7 @@ Or using `docker-compose`:
 version: '3.3'
 services:
     wego_overseer:
-        retart: unless-stopped
+        restart: unless-stopped
         environment:
             # Docker will automagically pull these from .env
             DISCORD_APPLICATION_ID: ${DISCORD_APPLICATION_ID}


### PR DESCRIPTION
Fixed typo in [DEPLOYMENT.md](https://github.com/rickklaasboer/wego-overseer/blob/d6646ee36d051b026fdf0cb18544f80f8c6f16cb/DEPLOYMENT.md?plain=1#L35) on line 35.

Changed from `retart: unless-stopped` to `restart: unless-stopped`

As you can see, the word restart was first spelled as retart. This was wrong because retart is not a valid flag in a docker-compose file. To fix this issue, i changed the word retart to restart. The difference was a 's' before the first 't'.