### PR TITLE
fix: semantic-release workflow

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -8,10 +8,16 @@ on:
 
 jobs:
     release:
-        if: github.actor != 'semantic-release-bot'
+        if: github.actor != 'semantic-release-bot' && github.actor != 'wego-gg'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                persist-credentials: false
+            - uses: webfactory/ssh-agent@v0.7.0
+              with:
+                ssh-private-key: ${{ secrets.GH_SSH_KEY }}
             - uses: actions/setup-node@v2
               with:
                   node-version: 18


### PR DESCRIPTION
This pull request is intended to address the previously discussed issue within the semantic-release workflow.

Please ensure the following steps are completed before merging:
- [x] Create the `wego-gg` (or whatever) GitHub account, don't use your personal account anymore.
- [x] Update the `GH_TOKEN` secret to the token created using the `wego-gg` account.
- [x] Create the `GH_SSH_KEY` secret and store a newly created *private* ssh key.
- [x] Add the public part of the newly created key to the newly created GitHub account.

As a result, the semantic release will now use SSH for pushing changes to the repository, using the key specified in the Actions secrets. This configuration ensures the correct triggering of actions upon tag creation. Profit!