### PR TITLE
fix: enable karma in every channel

### DIFF
--- a/src/app/events/karma/KarmaDownvoteEvent.ts
+++ b/src/app/events/karma/KarmaDownvoteEvent.ts
@@ -58,8 +58,6 @@ export default class KarmaDownvoteEvent
                 throw new Error('Channel is not available');
             }
 
-            if (!channel.isKarmaChannel) return;
-
             await this.removeExistingVotes(reaction.message, user);
 
             const values = {

--- a/src/app/events/karma/KarmaRemoveDownvoteEvent.ts
+++ b/src/app/events/karma/KarmaRemoveDownvoteEvent.ts
@@ -55,8 +55,6 @@ export default class KarmaRemoveDownvoteEvent
                 throw new Error('Channel is not available');
             }
 
-            if (!channel.isKarmaChannel) return;
-
             const values = {
                 messageId: reaction.message.id,
                 channelId: reaction.message.channel.id,

--- a/src/app/events/karma/KarmaRemoveUpvoteEvent.ts
+++ b/src/app/events/karma/KarmaRemoveUpvoteEvent.ts
@@ -55,8 +55,6 @@ export default class KarmaRemoveUpvoteEvent
                 throw new Error('Channel is not available');
             }
 
-            if (!channel.isKarmaChannel) return;
-
             const values = {
                 messageId: reaction.message.id,
                 channelId: reaction.message.channel.id,

--- a/src/app/events/karma/KarmaUpvoteEvent.ts
+++ b/src/app/events/karma/KarmaUpvoteEvent.ts
@@ -58,8 +58,6 @@ export default class KarmaUpvoteEvent
                 throw new Error('Channel is not available');
             }
 
-            if (!channel.isKarmaChannel) return;
-
             await this.removeExistingVotes(reaction.message, user);
 
             const values = {


### PR DESCRIPTION
Enables receiving karma in every channel instead of only karma channels. Karma channels should automatically receive upvotes and downvotes reactions but karma should still be rewarded for channels other than karma channels. Honestly, non-karma channels should receive double karma because the upvote effort was twice as big if you'd ask me