### PR TITLE
fix: remove comma's from `.env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,10 +52,10 @@ KABELBAAN_DISCORD_ID=
 NOOB_EMOJI_ID=
 
 # kanikeenkortebroekaan.nl API url
-KANIKEENKORTEBROEKAAN_API_URL="https://xxxxxxxxxx.execute-api.eu-west-1.amazonaws.com/production",
+KANIKEENKORTEBROEKAAN_API_URL="https://xxxxxxxxxx.execute-api.eu-west-1.amazonaws.com/production"
 
 # duo.nl API url
-DUO_STUFI_API_URL="https://xxxxxxxxxx.execute-api.eu-west-1.amazonaws.com/production",
+DUO_STUFI_API_URL="https://xxxxxxxxxx.execute-api.eu-west-1.amazonaws.com/production"
 
 # AWS credentials
 AWS_ACCESS_KEY_ID=


### PR DESCRIPTION
Comma's a preventing running the application after copying the example `.env` file